### PR TITLE
Remove broken link for 3dshap.es

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -297,13 +297,6 @@ Self-Hostable:
 [3yourmind]: https://3yourmind.com
 
 
-## Search Engines
-
-- [3Dshap.es] - Find 3D Printable Designs Using 3D shapes.
-
-[3Dshap.es]: https://3dshap.es
-
-
 ## Technologies
 
 - [Carbon3D] - Balancing the interaction of light and oxygen for fast resin based 3D printing.


### PR DESCRIPTION
Seems like the domain registration expired or something - site is no longer there.

Unfortunately this was the only link in this category, so I've taken that category header out as well.