### PR TITLE
fix: use a section with the right name for the TOC

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A curated list of awesome 3D printing resources.
 
-**Table Of Contents**
+## Contents
 
 <!-- toc -->
 


### PR DESCRIPTION
Following the Awesome list guidelines, the Table of Content should be a section and be named `Contents`, not `Table of Contents`.