### PR TITLE
ci: check urls everyday at midnight

### DIFF
--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -1,0 +1,22 @@
+name: 🌐 Check URLs
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # runs at 00:00 UTC every day
+    - cron: "0 0 * * *"
+
+jobs:
+  check-urls:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links
+        uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374 # v2.2.0
+        with:
+          args: |
+            --accept 403,429 --exclude 'https://www\.autodesk\.com'
+            --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'
+      - name: Fail if there were broken links
+        run: exit ${{ steps.lc.outputs.exit_code }}

--- a/contributing.md
+++ b/contributing.md
@@ -8,7 +8,7 @@ Please ensure your pull request adheres to the following guidelines:
     as yours may be a duplicate.
 - Make sure the resource is useful before submitting.
 - Make an individual pull request for each suggestion.
-- Use [title-casing](http://titlecapitalization.com) (AP style).
+- Use [title-casing](https://capitalizemytitle.com) (AP style).
 - Use the following format: `[Resource Name](link) - Description text.`
 - New categories or improvements to the existing categorization are welcome.
 - Check your spelling and grammar.

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ A curated list of awesome 3D printing resources.
 - [SolveSpace] - Minimalist CAD software. (open source)
 - [Tinkercad] - Browser based free app for 3D design, electronics, and coding.
 
-[AutoCAD]: https://autodesk.com/products/autocad/overview
+[AutoCAD]: https://www.autodesk.com/products/autocad/overview
 [Autodesk Fusion 360]: https://www.autodesk.com/products/fusion-360/personal
 [Blender]: https://www.blender.org/
 [FreeCAD]: https://freecadweb.org
@@ -226,7 +226,7 @@ Convert 3D models into G-Code.
 
 [iSense 3D scanner]: https://cubify.com/products/isense
 [MakerBot Digitizer]: https://makerbot.com/makerware-for-digitizer
-[Matter and Form]: https://matterandform.net/scanner
+[Matter and Form]: https://matterandform.net
 [Sense]: https://cubify.com/products/sense
 
 


### PR DESCRIPTION
This is using GitHub Actions for CI.

The following status codes are accepted:
- 403 (forbidden): turbosquid, monoprice
- 429 (too many requests): thingiverse.

The following site is excluded as it times out every time:
- autodesk.