### PR TITLE
Add build123d to CAD Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,7 @@ A curated list of awesome 3D printing resources.
 - [Autodesk Fusion 360] - 3D CAD, CAM, and CAE tool for product design
     and manufacturing. (free for personal / non-commercial use)
 - [Blender] - 3D modeling and sculpting app. (open source)
+- [build123d] - 3D CAD design software for python programmers (open source)
 - [FreeCAD]
 - [OpenSCAD]
 - [Rhinoceros 3D] - CAD application software. (commercial)
@@ -104,6 +105,7 @@ A curated list of awesome 3D printing resources.
 [AutoCAD]: https://www.autodesk.com/products/autocad/overview
 [Autodesk Fusion 360]: https://www.autodesk.com/products/fusion-360/personal
 [Blender]: https://www.blender.org/
+[build123d]: https://github.com/gumyr/build123d
 [FreeCAD]: https://www.freecad.org/
 [OpenSCAD]: https://openscad.org
 [Rhinoceros 3D]: https://www.rhino3d.com


### PR DESCRIPTION
Adds build123d to the CAD Tools category. Note the (lack of) capitalization, which is correct (a python project convention). I linked only to the main [repository](https://github.com/gumyr/build123d) but there is also a [docs](https://build123d.readthedocs.io/en/latest/) page.